### PR TITLE
Release 2 Patch 3 - add per-node enable_nlb flag and conditional Load Balancer provisioning

### DIFF
--- a/examples/create-vm-with-existing-vnet/terraform.tfvars
+++ b/examples/create-vm-with-existing-vnet/terraform.tfvars
@@ -142,32 +142,40 @@ virtual_machines_pan = {
 }
 
 
-# Enter the PSN node hostname as key and other allowed attributes in the values - (Allowed attribues size, storage, services, roles) comma space separated, currently only Eight PSN nodes are supported in this ISE stack deployment.
+# Specify instance configuration for N PSN nodes. It should follow below syntax where key is the hostname and values are instance attributes.
 # NOTE: Hostname only supports alphanumeric characters and hyphen (-). The length of the hostname should not exceed 19 characters, otherwise deployment will fail
-
+# Allowed values for enable_nlb : true or false. Specify true to add the ISE nodes as targets for Load Balancer, default value is false.
 /*
-This is the reference block for ISE node variables -  How to update the variable and it's attributes
-  {
+ {
     <hostname> = {
-      size = "<vm_size>"
-      storage = "<storage_size>"
-      services =  "<service_1>,<service_2>"
-      roles = "<role_1>,<role_2>"
+      size        = "<vm_size>"
+      storage     = "<storage_size>"
+      services    = "<service_1>,<service_2>"
+      roles       = "<role_1>,<role_2>"
+      enable_nlb  = true|false
     }
   }
 
+Please use below example for the reference.
 
-Example usage -
-
-virtual_machines_psn = {
-  ise-psn-node-2: {
-    roles: "PrimaryDedicatedMonitoring"
-    services: "Session, Profiler, pxGrid"
-    size: "Standard_B2ms"
-    storage: 500
-  }
+  virtual_machines_psn = {
+    secmonitoring-server = {
+      size       = "Standard_D8s_v4"
+      storage    = 500
+      roles      = "SecondaryDedicatedMonitoring"
+      enable_nlb = true
+    }
+    ise-psn-node-2 = {
+      size       = "Standard_D4s_v4"
+      storage    = 600
+      services   = "Session,Profiler,PassiveIdentity"
+      enable_nlb = true
+    }
+    ise-psn-node-3 = {
+      size      = "Standard_F16s_v2"
+      storage   = 700
+    }
 }
-
 */
 
 virtual_machines_psn = {

--- a/examples/create-vm-with-existing-vnet/variables.tf
+++ b/examples/create-vm-with-existing-vnet/variables.tf
@@ -354,10 +354,11 @@ variable "virtual_machines_pan" {
   }
   EOT
   type = map(object({
-    size     = string
-    storage  = number
-    services = optional(string)
-    roles    = optional(string, "SecondaryAdmin")
+    size       = string
+    storage    = number
+    services   = optional(string)
+    roles      = optional(string, "SecondaryAdmin")
+    enable_nlb = optional(bool, false)
   }))
   # default = {
   #   ise-pan-primary   = { size = "Standard_B2ms", storage = 400 } # NOTE: Don't pass the values for services and roles in Primary Node.
@@ -389,10 +390,11 @@ variable "virtual_machines_psn" {
   }
   EOT
   type = map(object({
-    size     = string
-    storage  = number
-    services = optional(string)
-    roles    = optional(string)
+    size       = string
+    storage    = number
+    services   = optional(string)
+    roles      = optional(string)
+    enable_nlb = optional(bool, false)
   }))
   # default = {
   #   ise-psn-node-1 = { size = "Standard_D4s_v4", storage = 500, services = "Session, Profiler, SXP, DeviceAdmin" }

--- a/examples/create-vm-with-new-vnet/terraform.tfvars
+++ b/examples/create-vm-with-new-vnet/terraform.tfvars
@@ -164,32 +164,40 @@ virtual_machines_pan = {
 }
 
 
-# Enter the PSN node hostname as key and other allowed attributes in the values - (Allowed attribues size, storage, services, roles) comma space separated, currently only Eight PSN nodes are supported in this ISE stack deployment.
+# Specify instance configuration for N PSN nodes. It should follow below syntax where key is the hostname and values are instance attributes.
 # NOTE: Hostname only supports alphanumeric characters and hyphen (-). The length of the hostname should not exceed 19 characters, otherwise deployment will fail
-
+# Allowed values for enable_nlb : true or false. Specify true to add the ISE nodes as targets for Load Balancer, default value is false.
 /*
-This is the reference block for ISE node variables -  How to update the variable and it's attributes
-  {
+ {
     <hostname> = {
-      size = "<vm_size>"
-      storage = "<storage_size>"
-      services =  "<service_1>,<service_2>"
-      roles = "<role_1>,<role_2>"
+      size        = "<vm_size>"
+      storage     = "<storage_size>"
+      services    = "<service_1>,<service_2>"
+      roles       = "<role_1>,<role_2>"
+      enable_nlb  = true|false
     }
   }
 
+Please use below example for the reference.
 
-Example usage -
-
-virtual_machines_psn = {
-  ise-psn-node-2: {
-    roles: "PrimaryDedicatedMonitoring"
-    services: "Session, Profiler, pxGrid"
-    size: "Standard_B2ms"
-    storage: 500
-  }
+  virtual_machines_psn = {
+    secmonitoring-server = {
+      size       = "Standard_D8s_v4"
+      storage    = 500
+      roles      = "SecondaryDedicatedMonitoring"
+      enable_nlb = true
+    }
+    ise-psn-node-2 = {
+      size       = "Standard_D4s_v4"
+      storage    = 600
+      services   = "Session,Profiler,PassiveIdentity"
+      enable_nlb = true
+    }
+    ise-psn-node-3 = {
+      size      = "Standard_F16s_v2"
+      storage   = 700
+    }
 }
-
 */
 
 virtual_machines_psn = {

--- a/examples/create-vm-with-new-vnet/terraform.tfvars
+++ b/examples/create-vm-with-new-vnet/terraform.tfvars
@@ -197,6 +197,7 @@ virtual_machines_psn = {
     services : "Session, Profiler, SXP, DeviceAdmin"
     size : "Standard_D4s_v4"
     storage : 500
+    enable_nlb : false
   }
 
   # ise-psn-node-02 : {

--- a/examples/create-vm-with-new-vnet/variables.tf
+++ b/examples/create-vm-with-new-vnet/variables.tf
@@ -367,10 +367,11 @@ variable "virtual_machines_pan" {
   }
   EOT
   type = map(object({
-    size     = string
-    storage  = number
-    services = optional(string)
-    roles    = optional(string, "SecondaryAdmin")
+    size       = string
+    storage    = number
+    services   = optional(string)
+    roles      = optional(string, "SecondaryAdmin")
+    enable_nlb = optional(bool, false)
   }))
 
   validation {
@@ -398,10 +399,11 @@ variable "virtual_machines_psn" {
   }
   EOT
   type = map(object({
-    size     = string
-    storage  = number
-    services = optional(string)
-    roles    = optional(string)
+    size       = string
+    storage    = number
+    services   = optional(string)
+    roles      = optional(string)
+    enable_nlb = optional(bool, false)
   }))
 
   validation {

--- a/module/loadbalancer_dns/functionapp.tf
+++ b/module/loadbalancer_dns/functionapp.tf
@@ -22,12 +22,12 @@ data "azurerm_subnet" "ise_func_subnet" {
 
 
 resource "azurerm_storage_account" "ise-app-storage" {
-  name                          = "iseappstorage${random_string.function_app_suffix.result}"
-  resource_group_name           = var.ise_resource_group
-  location                      = var.location
-  account_tier                  = "Standard"
-  account_replication_type      = "GRS"
-  public_network_access_enabled = false
+  name                            = "iseappstorage${random_string.function_app_suffix.result}"
+  resource_group_name             = var.ise_resource_group
+  location                        = var.location
+  account_tier                    = "Standard"
+  account_replication_type        = "GRS"
+  public_network_access_enabled   = false
   allow_nested_items_to_be_public = false
 }
 

--- a/module/loadbalancer_dns/locals.tf
+++ b/module/loadbalancer_dns/locals.tf
@@ -26,4 +26,7 @@ locals {
   username_password_key     = var.username_password_key
   username_password_value   = [var.ise_vm_adminuser_name, var.password]
   combined_user_password_kv = zipmap(local.username_password_key, local.username_password_value)
+  create_nlb                = anytrue(flatten([for vm in [var.virtual_machines_pan, var.virtual_machines_psn] : [for instance, details in vm : details.enable_nlb]]))
+  combined_nodes            = merge(var.virtual_machines_pan, var.virtual_machines_psn)
+  enabled_nodes             = [for vm_name, vm_attribute in local.combined_nodes : vm_name if vm_attribute.enable_nlb == true]
 }

--- a/module/loadbalancer_dns/output.tf
+++ b/module/loadbalancer_dns/output.tf
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 output "ise-vm-backendpool" {
-  value = azurerm_lb_backend_address_pool.ise-vm-backendpool.id
+  value = azurerm_lb_backend_address_pool.ise-vm-backendpool[*].id
 }
 
 # output "ise_vm_private_dns_zone" {
@@ -32,5 +32,5 @@ output "private_dns_records" {
 # }
 
 output "loadbalancer_frontendIP" {
-  value = azurerm_lb.ise-lb.private_ip_address
+  value = azurerm_lb.ise-lb[*].private_ip_address
 }

--- a/module/loadbalancer_dns/variable.tf
+++ b/module/loadbalancer_dns/variable.tf
@@ -184,18 +184,20 @@ variable "github_repo" {
 
 variable "virtual_machines_pan" {
   type = map(object({
-    size     = string
-    storage  = number
-    services = optional(string)
-    roles    = optional(string)
+    size       = string
+    storage    = number
+    services   = optional(string)
+    roles      = optional(string)
+    enable_nlb = optional(bool, false)
   }))
 }
 
 variable "virtual_machines_psn" {
   type = map(object({
-    size     = string
-    storage  = number
-    services = optional(string, "Session, Profiler")
-    roles    = optional(string)
+    size       = string
+    storage    = number
+    services   = optional(string, "Session, Profiler")
+    roles      = optional(string)
+    enable_nlb = optional(bool, false)
   }))
 }


### PR DESCRIPTION
Cisco ISE Terraform Azure Release 2 #Patch 3
The user should have the ability to enable or disable the Azure Load Balancer based on their requirements. This feature enhances flexibility and helps reduce the cost.
The User should be able to specify the Azure VMs that need to be attached to the Azure Load Balancer using the terraform.tfvars file.